### PR TITLE
Specify border color on table component

### DIFF
--- a/src/View/Components/Table/Index.php
+++ b/src/View/Components/Table/Index.php
@@ -44,7 +44,7 @@ class Index extends Component
     {
         return <<<'HTML'
             <div @class([
-                "dark:border-gray-700", 
+                "border-gray-200 dark:border-gray-700", 
                 $shadowClass(), 
                 $roundedClass(),
                 'border divide-y divide-gray-200 dark:divide-gray-700' => !$attributes->get('borderless'),


### PR DESCRIPTION
Table component has the class "border" but no class to specify its color (in light mode) 
In my typical environment, this produces a black border. 
Just added the border in gray-200 to match other dividers.