### PR TITLE
Dropdown list-style & border

### DIFF
--- a/src/View/Components/Dropdown.php
+++ b/src/View/Components/Dropdown.php
@@ -225,7 +225,7 @@ class Dropdown extends Component
                 >
                     <ul 
                        {{ $attributes->twMerge([
-                                "ring-1 ring-black dark:ring-gray-700 ring-opacity-5 dark:bg-gray-800 dark:text-gray-100",
+                                "list-none ring-1 ring-gray-200 dark:ring-gray-700 dark:bg-gray-800 dark:text-gray-100",
                                 $roundedClass(),  
                                 $title ? 'py-1' : '',
                             ]) 


### PR DESCRIPTION
In Tailwind 4 context, sometimes the ul bullet appears outside the dropdown element. It's fixed by `.list-none`

The `.ring-opacity-5` seems to not working on TW4, and for consistency with dark variant & other components (separator) I suggest to replace `.ring-black .ring-opacity-5` by `.ring-gray-200`