### PR TITLE
Preserve case in Label component

### DIFF
--- a/src/View/Components/Label.php
+++ b/src/View/Components/Label.php
@@ -20,7 +20,7 @@ class Label extends Component
         return <<<'HTML'
             @php
                 // Remove extra space & make label lowercase
-                $label = trim(Str::lower($label));
+                $label = trim($label);
 
                 // Check if the label contains '*'
                 $hasStar = strpos($label, '*') !== false;
@@ -42,7 +42,7 @@ class Label extends Component
                     ])
                 }}
             >     
-                {{ Str::ucfirst(__($labelWithoutStar)) }}
+                {{ __($labelWithoutStar) }}
 
                 @if ($isRequired)
                     <span class="text-red-500">*</span>


### PR DESCRIPTION
I don't know why the labels are converted to lowercase, but it can be problematic on radio buttons and checkboxes for example. I suggest leaving the label as it is sent in the input attribute.

There is another topic about automatic translations of texts sent to components with `__()` which seems questionable to me, but it is broader and would require work on many components.