### PR TITLE
Select : fix & dynamic size

### DIFF
--- a/config/tallcraftui.php
+++ b/config/tallcraftui.php
@@ -146,6 +146,7 @@ return [
     ],
 
     'input' => [
+        'size' => Size::MD->value,
         'border-radius' => BorderRadius::Rounded->value,
     ],
 

--- a/config/tallcraftui.php
+++ b/config/tallcraftui.php
@@ -150,16 +150,17 @@ return [
         'border-radius' => BorderRadius::Rounded->value,
     ],
 
+    'select' => [
+        'size' => Size::MD->value,
+        'border-radius' => BorderRadius::Rounded->value,
+    ],
+
     'radio' => [
         'size' => Size::MD->value,
     ],
 
     'rating' => [
         'size' => Size::MD->value,
-    ],
-
-    'select' => [
-        'border-radius' => BorderRadius::Rounded->value,
     ],
 
     'textarea' => [

--- a/src/View/Components/Input.php
+++ b/src/View/Components/Input.php
@@ -103,14 +103,62 @@ class Input extends Component
         return $this->attributes->get('readonly') ? 'bg-gray-200 opacity-80 border-gray-400 border-dashed pointer-events-none' : '';
     }
 
+    public function sizeClasses(): string
+    {
+        $sizes = [
+            'xs' => 'py-1 text-xs',
+            'sm' => 'py-1.5 text-xs',
+            'md' => 'py-2 text-sm',
+            'lg' => 'py-2.5 text-base',
+            'xl' => 'py-3 text-lg',
+            '2xl' => 'py-3.5 text-xl',
+        ];
+
+        foreach ($sizes as $key => $class) {
+            if ($this->attributes->has($key)) {
+                return $class;
+            }
+        }
+
+        $defaultSize = config('tallcraftui.input.size', 'md');
+
+        return $sizes[$defaultSize] ?? $sizes['md'];
+    }
+
+    public function addonSizeClasses(): string
+    {
+        $sizes = [
+            'xs' => 'px-1.5 py-1 text-xs',
+            'sm' => 'px-2 py-1.5 text-xs',
+            'md' => 'px-3 py-2 text-sm',
+            'lg' => 'px-4 py-3 text-base',
+            'xl' => 'px-5 py-4 text-lg',
+            '2xl' => 'px-6 py-3.5 text-xl',
+        ];
+
+        foreach ($sizes as $key => $class) {
+            if ($this->attributes->has($key)) {
+                return $class;
+            }
+        }
+
+        $defaultSize = config('tallcraftui.input.size', 'md');
+
+        return $sizes[$defaultSize] ?? $sizes['md'];
+    }
+
     public function prefixPrependClass(): string
     {
-        return $this->prefix || $this->prepend && $this->prependIsSelect === false ? 'px-2.5 xs:px-3 sm:px-4 py-2.5 border border-gray-200 dark:border-gray-700' : '';
+        return $this->prefix || $this->prepend && $this->prependIsSelect === false
+            ? 'border border-gray-200 dark:border-gray-700 ' . $this->addonSizeClasses()
+            : '';
     }
 
     public function suffixAppendClass(): string
     {
-        return $this->suffix || $this->append && $this->appendIsSelect === false ? 'px-2.5 xs:px-3 sm:px-4 py-2.5 border border-gray-200 dark:border-gray-700' : '';
+        return $this->suffix || $this->append && $this->appendIsSelect === false
+            ? 'border border-gray-200 dark:border-gray-700 ' . $this->addonSizeClasses()
+            : '';
     }
 
     public function render(): View|Closure|string
@@ -159,7 +207,8 @@ class Input extends Component
                                     ->merge(['type' => 'text'])
                                     ->withoutTwMergeClasses()
                                     ->twMerge([
-                                        "block w-full border-gray-200 py-2.5 shadow-sm text-sm outline-none focus:ring-primary focus:border-primary dark:focus:border-primary dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:placeholder-gray-400",
+                                        "block w-full border-gray-200 shadow-sm outline-none focus:ring-primary focus:border-primary dark:focus:border-primary dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:placeholder-gray-400",
+                                        $sizeClasses(),
                                         $iconLeftClass(),
                                         $iconRightClass(),
                                         $inputPrefixPrependClass(),
@@ -169,6 +218,8 @@ class Input extends Component
                                         $readonlyClass(),
                                         $roundedClass(),
                                         $errorClass,
+                                        filled($prepend) ? 'rounded-l-none' : '',
+                                        filled($append) ? 'rounded-r-none' : '',
                                     ])
                                 }} 
                             />

--- a/src/View/Components/Select.php
+++ b/src/View/Components/Select.php
@@ -26,6 +26,28 @@ class Select extends Component
         return BorderRadiusHelper::getRoundedClass('select', $this->attributes);
     }
 
+    public function sizeClasses(): string
+    {
+        $sizes = [
+            'xs' => 'py-1 text-xs',
+            'sm' => 'py-1.5 text-xs',
+            'md' => 'py-2 text-sm',
+            'lg' => 'py-2.5 text-base',
+            'xl' => 'py-3 text-lg',
+            '2xl' => 'py-3.5 text-xl',
+        ];
+
+        foreach ($sizes as $key => $class) {
+            if ($this->attributes->has($key)) {
+                return $class;
+            }
+        }
+
+        $defaultSize = config('tallcraftui.select.size', 'md');
+
+        return $sizes[$defaultSize] ?? $sizes['md'];
+    }
+
     public function render(): View|Closure|string
     {
         return <<<'HTML'
@@ -53,7 +75,8 @@ class Select extends Component
                                 $attributes
                                     ->withoutTwMergeClasses()
                                     ->twMerge([
-                                        "block w-full border-gray-200 py-2.5 shadow-sm text-sm outline-none focus:ring-primary focus:border-primary dark:focus:border-primary dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300",
+                                        "block w-full border-gray-200 shadow-sm outline-none focus:ring-primary focus:border-primary dark:focus:border-primary dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300",
+                                        $sizeClasses(),
                                         $errorClass,
                                         $disabledClass,
                                         $readonlyClass,


### PR DESCRIPTION
Now you can use `sizes` in your select and customize the `select` default size from `tallcraftui.php` config :

```blade
<x-select xs />
<x-select sm />
<x-select md />
<x-select lg />
<x-select xl />
<x-select 2xl />
```

`app > config > tallcraftui.php`

```php
'select' => [
    'size' => Size::MD->value,
],
```