### PR TITLE
Select : refactor & improved

### DIFF
--- a/src/Traits/HasSelectSizes.php
+++ b/src/Traits/HasSelectSizes.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Developermithu\Tallcraftui\Traits;
+
+trait HasSelectSizes
+{
+    public function getSizeClasses(): string
+    {
+        $sizes = [
+            'xs' => 'py-1 text-xs',
+            'sm' => 'py-1.5 text-xs',
+            'md' => 'py-2 text-sm',
+            'lg' => 'py-2.5 text-base',
+            'xl' => 'py-3 text-lg',
+            '2xl' => 'py-3.5 text-xl',
+        ];
+
+        foreach ($sizes as $key => $class) {
+            if ($this->attributes->has($key)) {
+                return $class;
+            }
+        }
+
+        $defaultSize = config('tallcraftui.select.size', 'md');
+
+        return $sizes[$defaultSize] ?? $sizes['md'];
+    }
+}


### PR DESCRIPTION

- Refactor select component
- Add support for `array`
- Add `option-value` `option-label` and `without-placeholder` props
- Default `option-value="id"` and `option-label="name"` 

Example usages:

```blade
@php
    $users1 = App\Models\User::pluck('name', 'id');
    $users2 = App\Models\User::get();

    $posts= App\Models\Post::get();
@endphp

<x-tc-select wire:model="user_id" :options="$users1" />
<x-tc-select wire:model="user_id" :options="$users2" />
<x-tc-select wire:model="color" :options="['Red', 'Green', 'Blue']" />

<x-tc-select 
    wire:model="post_id" 
    :options="$posts" 
    option-value="id"
    option-label="title"
    without-placeholder
/>
```